### PR TITLE
Update r-systemfonts via conda forge for svglite.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,7 +4,7 @@ LABEL maintainer="LSIT Systems <lsitops@ucsb.edu>"
 
 USER root
 
-RUN conda install -y -c conda-forge r-svglite
+RUN conda install -y -c conda-forge r-systemfonts r-svglite
 
 RUN R -e "install.packages(c('psych', 'afex', 'Hmisc', 'emmeans', 'ggplot2', 'lsr'), repos = 'https://cloud.r-project.org/', Ncpus = parallel::detectCores())"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
                         container('podman') {
                             sh 'podman run -it --rm localhost/$IMAGE_NAME which rstudio'
                             sh 'podman run -it --rm localhost/$IMAGE_NAME R -q -e "getRversion() >= \\"4.1.3\\"" | tee /dev/stderr | grep -q "TRUE"'
-                            sh 'podman run -it --rm localhost/$IMAGE_NAME R -e "library(\"psych\");library(\"afex\");library(\"Hmisc\");library(\"emmeans\");library(\"tidyverse\");library(\"ggplot2\");library(\"lsr\");library(\"knitr\");library(\"svglite\")"'
+                            sh 'podman run -it --rm localhost/$IMAGE_NAME R -e "library(\"psych\");library(\"afex\");library(\"Hmisc\");library(\"emmeans\");library(\"tidyverse\");library(\"ggplot2\");library(\"lsr\");library(\"knitr\");library(\"svglite\");library(\"systemfonts\")"'
                             sh 'podman run -d --name=$IMAGE_NAME --rm -p 8888:8888 localhost/$IMAGE_NAME start-notebook.sh --NotebookApp.token="jenkinstest"'
                             sh 'sleep 10 && curl -v http://localhost:8888/rstudio?token=jenkinstest 2>&1 | grep -P "HTTP\\S+\\s[1-3][0-9][0-9]\\s+[\\w\\s]+\\s*$"'
                             sh 'curl -v http://localhost:8888/lab?token=jenkinstest 2>&1 | grep -P "HTTP\\S+\\s200\\s+[\\w\\s]+\\s*$"'


### PR DESCRIPTION
Fix for this:

```
[36mℹ[39m Use the conflicted package ([3m[34m<http://conflicted.r-lib.org/>[39m[23m) to force all conflicts to become errors
[?25h[?25h[?25h[?25hError: package or namespace load failed for ‘svglite’ in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]):
 namespace ‘systemfonts’ 1.2.3 is being loaded, but >= 1.3.0 is required
 ```